### PR TITLE
Handle EOFs for metainfo in metrics endpoint

### DIFF
--- a/pkg/server/gateway.go
+++ b/pkg/server/gateway.go
@@ -195,7 +195,11 @@ func (g *Gateway) Open() error {
 
 			info, err := mi.UnmarshalInfo()
 			if err != nil {
-				panic(err)
+				log.Error().
+					Err(err).
+					Msg("Could not unmarshal metainfo")
+
+				continue
 			}
 
 			fileMetrics := []v1.FileMetrics{}


### PR DESCRIPTION
This allows fetching metrics for a torrent before it has started downloading.